### PR TITLE
Add Message to Conversation API to Assistant Orchestrator

### DIFF
--- a/src/orchestrators/assistant-orchestrator/orchestrator/conversation_manager.py
+++ b/src/orchestrators/assistant-orchestrator/orchestrator/conversation_manager.py
@@ -15,6 +15,14 @@ class ConversationManager:
     def get_conversation(self, user_id: str, session_id: str) -> Conversation:
         return self.services_client.get_conversation(user_id, session_id)
 
+    def get_last_response(self, conversation: Conversation):
+        return Conversation(
+            conversation_id=conversation.conversation_id,
+            user_id=conversation.user_id,
+            history=conversation.history[-2:] if len(conversation.history) >= 2 else conversation.history,
+            user_context=conversation.user_context
+        )
+    
     def add_user_message(
         self, conversation: Conversation, content: str, recipient: str
     ) -> None:

--- a/src/orchestrators/assistant-orchestrator/orchestrator/model/requests.py
+++ b/src/orchestrators/assistant-orchestrator/orchestrator/model/requests.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel, Field
+
+
+class ConversationMessageRequest(BaseModel):
+    message: str

--- a/src/orchestrators/assistant-orchestrator/orchestrator/routes/deps.py
+++ b/src/orchestrators/assistant-orchestrator/orchestrator/routes/deps.py
@@ -43,7 +43,7 @@ def initialize() -> None:
     for agent_name in _config.spec.agents:
         agents[agent_name] = agent_builder.build_agent(agent_name, api_key)
     _agent_catalog = AgentCatalog(agents=agents)
-
+    
     _fallback_agent = agent_builder.build_fallback_agent(
         _config.spec.fallback_agent, api_key, _agent_catalog
     )


### PR DESCRIPTION
## Description
Added "Add Message to Conversation by ID" to the Assistant Orchestrator API. This includes updating agent endpoints to allow for http/https and websocket calls. The API response similarly to how the websocket works on choosing an agent and getting the agent response along with processing any extra data passed.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- Added Add Conversation by ID which picks an agent, sets up fallback agent, works with API endpoints, and returns the latest user/agent messages.

## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________
