### PR TITLE
Add ability to set user context values using REST APIs

### DIFF
--- a/src/orchestrators/assistant-orchestrator/orchestrator/conversation_manager.py
+++ b/src/orchestrators/assistant-orchestrator/orchestrator/conversation_manager.py
@@ -81,6 +81,14 @@ class ConversationManager:
                 conversation.user_id, item_key, item_value
             )
 
+    def add_user_context_item(
+        self,
+        user_id: str,
+        item_key: str,
+        item_value: str
+    ) -> None:
+        self.services_client.add_context_item(user_id, item_key, item_value)
+
     def update_context_item(
         self, conversation: Conversation, item_key: str, item_value: str
     ) -> None:

--- a/src/orchestrators/assistant-orchestrator/orchestrator/model/__init__.py
+++ b/src/orchestrators/assistant-orchestrator/orchestrator/model/__init__.py
@@ -3,3 +3,5 @@ from .conversation import Conversation as Conversation
 from .conversation import UserMessage as UserMessage
 from .conversation import ContextType as ContextType
 from .conversation import ContextItem as ContextItem
+from .conversation import AddContextItemRequest as AddContextItemRequest
+from .requests import ConversationMessageRequest as ConversationMessageRequest

--- a/src/orchestrators/assistant-orchestrator/orchestrator/model/conversation.py
+++ b/src/orchestrators/assistant-orchestrator/orchestrator/model/conversation.py
@@ -13,6 +13,9 @@ class ContextItem(BaseModel):
     context_type: ContextType
     value: str
 
+class AddContextItemRequest(BaseModel):
+    item_key: str
+    item_value: str
 
 class UserMessage(BaseModel):
     content: str


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Added functionality to set user context using REST APIs.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- Updated new_conversation API to allow passing of optional body with user_context items
- Updated the "add message to conversation" API to allow passing user_context items (optionally) in the body of the request
- Added new add_context API to use specifically for setting user_context items

## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->

## Additional Comments
<!-- Include any other relevant information or comments here. -->
