### PR TITLE
Add authorization header to 'Add Conversation' API

### DIFF
--- a/src/sk-agents/src/sk_agents/skagents/v1/__init__.py
+++ b/src/sk-agents/src/sk_agents/skagents/v1/__init__.py
@@ -32,6 +32,6 @@ def _handle_sequential(
         chat_completion_builder, remote_plugin_loader, app_config
     )
     agent_builder = AgentBuilder(kernel_builder)
-    task_builder = TaskBuilder(agent_builder)
+    task_builder = TaskBuilder(agent_builder, authorization)
     seq_skagents = SequentialSkagents(config, kernel_builder, task_builder)
     return seq_skagents


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Added the ability to specify an optional authorization header for the 'Add Conversation' REST API.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- Modified the exiting 'Add Conversation' REST API to now accept an optional authorization header value

## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->

## Additional Comments
<!-- Include any other relevant information or comments here. -->
NOTE: "Authorization" is a reserved header in Swagger/OpenAPI and can't be overridden directly. That is why the implementation includes the package from `fastapi.security`. 
