### PR TITLE
Leverage structured output capability of primary model, if available

### DIFF
--- a/src/orchestrators/group-orchestrator/orchestrator/agents/kong/kong.yaml
+++ b/src/orchestrators/group-orchestrator/orchestrator/agents/kong/kong.yaml
@@ -33,7 +33,7 @@ services:
   enabled: true
   host: planning-agent
   name: PlanningAgentDocs
-  path: /openapi.json
+  path: /PlanningAgent/0.1/openapi.json
   port: 8000
   protocol: http
   read_timeout: 60000
@@ -87,7 +87,7 @@ services:
   enabled: true
   host: travel-planner-agent
   name: TravelPlannerAgentDocs
-  path: /openapi.json
+  path: /TravelPlannerAgent/0.1/openapi.json
   port: 8000
   protocol: http
   read_timeout: 60000
@@ -141,7 +141,7 @@ services:
   enabled: true
   host: local-agent
   name: LocalAgentDocs
-  path: /openapi.json
+  path: /LocalAgent/0.1/openapi.json
   port: 8000
   protocol: http
   read_timeout: 60000
@@ -195,7 +195,7 @@ services:
   enabled: true
   host: language-agent
   name: LanguageAgentDocs
-  path: /openapi.json
+  path: /LanguageAgent/0.1/openapi.json
   port: 8000
   protocol: http
   read_timeout: 60000
@@ -249,7 +249,7 @@ services:
   enabled: true
   host: travel-summary-agent
   name: TravelSummaryAgentDocs
-  path: /openapi.json
+  path: /TravelSummaryAgent/0.1/openapi.json
   port: 8000
   protocol: http
   read_timeout: 60000

--- a/src/orchestrators/group-orchestrator/orchestrator/src/group_orchestrator/agents/agent_gateway.py
+++ b/src/orchestrators/group-orchestrator/orchestrator/src/group_orchestrator/agents/agent_gateway.py
@@ -48,7 +48,6 @@ class AgentGateway(BaseModel):
 
         headers = {
             "taAgwKey": self.agw_key,
-            "Content-Type": "application/json",
         }
         inject(headers)
         async with websockets.connect(

--- a/src/sk-agents/demos/02_input_output/config.yaml
+++ b/src/sk-agents/demos/02_input_output/config.yaml
@@ -10,7 +10,7 @@ spec:
   agents:
     - name: default
       role: Default Agent
-      model: claude-3-7-sonnet-20250219-v1
+      model: gpt-4o-mini
       system_prompt: >
         You are a helpful assistant.
   tasks:

--- a/src/sk-agents/demos/02_input_output/config.yaml
+++ b/src/sk-agents/demos/02_input_output/config.yaml
@@ -10,7 +10,7 @@ spec:
   agents:
     - name: default
       role: Default Agent
-      model: gpt-4o
+      model: claude-3-7-sonnet-20250219-v1
       system_prompt: >
         You are a helpful assistant.
   tasks:

--- a/src/sk-agents/src/sk_agents/chat_completion/custom/example_custom_chat_completion_factory.py
+++ b/src/sk-agents/src/sk_agents/chat_completion/custom/example_custom_chat_completion_factory.py
@@ -86,3 +86,11 @@ class ExampleCustomChatCompletionFactory(ChatCompletionFactory):
             return ModelType.ANTHROPIC
         else:
             raise ValueError(f"Unknown model name {model_name}")
+
+    def model_supports_structured_output(self, model_name: str) -> bool:
+        if model_name in ExampleCustomChatCompletionFactory._OPENAI_MODELS:
+            return True
+        elif model_name in ExampleCustomChatCompletionFactory._ANTHROPIC_MODELS:
+            return False
+        else:
+            raise ValueError(f"Unknown model name {model_name}")

--- a/src/sk-agents/src/sk_agents/chat_completion/default_chat_completion_factory.py
+++ b/src/sk-agents/src/sk_agents/chat_completion/default_chat_completion_factory.py
@@ -33,3 +33,9 @@ class DefaultChatCompletionFactory(ChatCompletionFactory):
             return ModelType.OPENAI
         else:
             raise ValueError(f"Unknown model name {model_name}")
+
+    def model_supports_structured_output(self, model_name: str) -> bool:
+        if model_name in self._OPENAI_MODELS:
+            return True
+        else:
+            raise ValueError(f"Unknown model name {model_name}")

--- a/src/sk-agents/src/sk_agents/ska_types.py
+++ b/src/sk-agents/src/sk_agents/ska_types.py
@@ -98,7 +98,7 @@ class InvokeResponse(BaseModel, Generic[T]):
 
     token_usage: TokenUsage
     extra_data: Optional[ExtraData] = None
-    output_raw: str
+    output_raw: Optional[str] = None
     output_pydantic: Optional[T] = None
 
 
@@ -139,4 +139,8 @@ class ChatCompletionFactory(ABC):
 
     @abstractmethod
     def get_model_type_for_name(self, model_name: str) -> ModelType:
+        pass
+
+    @abstractmethod
+    def model_supports_structured_output(self, model_name: str) -> bool:
         pass

--- a/src/sk-agents/src/sk_agents/skagents/chat_completion_builder.py
+++ b/src/sk-agents/src/sk_agents/skagents/chat_completion_builder.py
@@ -77,3 +77,13 @@ class ChatCompletionBuilder:
                     f"Could not find model {model_name} using custom factory"
                 )
         return self.self_default_cc_factory.get_model_type_for_name(model_name)
+
+    def model_supports_structured_output(self, model_name: str) -> bool:
+        if self.ccc_factory:
+            try:
+                return self.ccc_factory.model_supports_structured_output(model_name)
+            except ValueError:
+                self.logger.warning(
+                    f"Could not find model {model_name} using custom factory"
+                )
+        return self.self_default_cc_factory.model_supports_structured_output(model_name)

--- a/src/sk-agents/src/sk_agents/skagents/kernel_builder.py
+++ b/src/sk-agents/src/sk_agents/skagents/kernel_builder.py
@@ -41,6 +41,9 @@ class KernelBuilder:
     def get_model_type_for_name(self, model_name: str) -> ModelType:
         return self.chat_completion_builder.get_model_type_for_name(model_name)
 
+    def model_supports_structured_output(self, model_name: str) -> bool:
+        return self.chat_completion_builder.model_supports_structured_output(model_name)
+
     def _create_base_kernel(self, model_name: str, service_id: str) -> Kernel:
         chat_completion = self.chat_completion_builder.get_chat_completion_for_model(
             service_id=service_id,

--- a/src/sk-agents/src/sk_agents/skagents/v1/agent_builder.py
+++ b/src/sk-agents/src/sk_agents/skagents/v1/agent_builder.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any
+
 from semantic_kernel.agents import ChatCompletionAgent
 from semantic_kernel.connectors.ai.function_choice_behavior import (
     FunctionChoiceBehavior,
@@ -9,6 +11,7 @@ from sk_agents.ska_types import ModelType
 from sk_agents.skagents.kernel_builder import KernelBuilder
 from sk_agents.skagents.v1.sequential.config import AgentConfig
 from sk_agents.skagents.v1.sk_agent import SKAgent
+from sk_agents.type_loader import get_type_loader
 
 
 class AgentBuilder:
@@ -20,6 +23,7 @@ class AgentBuilder:
         self,
         agent_config: AgentConfig,
         extra_data_collector: ExtraDataCollector | None = None,
+        output_type: str | None = None,
     ) -> SKAgent:
         kernel = self.kernel_builder.build_kernel(
             agent_config.model,
@@ -29,18 +33,31 @@ class AgentBuilder:
             self.authorization,
             extra_data_collector,
         )
+
+        so_supported: bool = self.kernel_builder.model_supports_structured_output(
+            agent_config.model
+        )
+
         settings = kernel.get_prompt_execution_settings_from_service_id(
             agent_config.name
         )
         settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
+        if so_supported and output_type:
+            type_loader = get_type_loader()
+            settings.response_format = type_loader.get_type(output_type)
 
         model_type: ModelType = self.kernel_builder.get_model_type_for_name(
             agent_config.model
         )
 
+        model_attributes: Dict[str, Any] = {
+            "model_type": model_type,
+            "so_supported": so_supported,
+        }
+
         return SKAgent(
             model_name=agent_config.model,
-            model_type=model_type,
+            model_attributes=model_attributes,
             agent=ChatCompletionAgent(
                 kernel=kernel,
                 name=agent_config.name,

--- a/src/sk-agents/src/sk_agents/skagents/v1/sequential/task.py
+++ b/src/sk-agents/src/sk_agents/skagents/v1/sequential/task.py
@@ -119,7 +119,9 @@ class Task:
         async for content in self.agent.invoke(history):
             response_content.append(content)
             history.add_message(content)
-            call_usage = get_token_usage_for_response(self.agent.model_type, content)
+            call_usage = get_token_usage_for_response(
+                self.agent.get_model_type(), content
+            )
             completion_tokens += call_usage.completion_tokens
             prompt_tokens += call_usage.prompt_tokens
             total_tokens += call_usage.total_tokens

--- a/src/sk-agents/src/sk_agents/skagents/v1/sequential/task_builder.py
+++ b/src/sk-agents/src/sk_agents/skagents/v1/sequential/task_builder.py
@@ -25,20 +25,26 @@ class TaskBuilder:
         task_config: TaskConfig,
         agent_configs: List[AgentConfig],
         extra_data_collector: ExtraDataCollector,
+        output_type: str | None = None,
     ) -> SKAgent:
         agent_config = TaskBuilder._get_agent_config_by_name(
             task_config.agent, agent_configs
         )
 
-        agent = self.agent_builder.build_agent(agent_config, extra_data_collector)
+        agent = self.agent_builder.build_agent(
+            agent_config, extra_data_collector, output_type
+        )
         return agent
 
     def build_task(
-        self, task_config: TaskConfig, agent_configs: List[AgentConfig]
+        self,
+        task_config: TaskConfig,
+        agent_configs: List[AgentConfig],
+        output_type: str | None = None,
     ) -> Task:
         extra_data_collector = ExtraDataCollector()
         agent = self._get_agent_for_task(
-            task_config, agent_configs, extra_data_collector
+            task_config, agent_configs, extra_data_collector, output_type
         )
         return Task(
             name=task_config.name,

--- a/src/sk-agents/src/sk_agents/skagents/v1/sk_agent.py
+++ b/src/sk-agents/src/sk_agents/skagents/v1/sk_agent.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterable
+from typing import AsyncIterable, Dict, Any
 
 from semantic_kernel.agents import ChatCompletionAgent
 from semantic_kernel.contents.chat_history import ChatHistory
@@ -12,14 +12,20 @@ from sk_agents.ska_types import ModelType
 
 class SKAgent:
     def __init__(
-        self, model_name: str, model_type: ModelType, agent: ChatCompletionAgent
+        self,
+        model_name: str,
+        model_attributes: Dict[str, Any],
+        agent: ChatCompletionAgent,
     ):
         self.model_name = model_name
-        self.model_type = model_type
         self.agent = agent
+        self.model_attributes = model_attributes
 
     def get_model_type(self) -> ModelType:
-        return self.model_type
+        return self.model_attributes["model_type"]
+
+    def so_supported(self) -> bool:
+        return self.model_attributes["so_supported"]
 
     async def invoke_stream(
         self, history: ChatHistory


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
This change switches how structured output is provided for agents in certain cases. If a particular agent's chosen model supports structured output, then that will be requested with the initial agent invocation rather than as a follow-on step. If the model does not support SO, then the conversion is then still performed as a follow-on step.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- Change 1
- Change 2
- Change 3

## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->

## Additional Comments
<!-- Include any other relevant information or comments here. -->
