### PR TITLE
Fix - Added Orchestrator to Authentication Service

### DIFF
--- a/src/orchestrators/assistant-orchestrator/services/auth/README.md
+++ b/src/orchestrators/assistant-orchestrator/services/auth/README.md
@@ -2,7 +2,8 @@
 ## Authentication
 
 By default, authentication for the assistant orchestrator is not secure and all
-that is required is a request with a payload containing a user ID of the format:
+that is required is the orchestrator name the authentication is performed and a 
+request with a payload containing a user ID of the format:
 
 ```json
 {
@@ -27,6 +28,8 @@ The Authenticator class must implement the following methods:
 * `authenticate` - This method accepts a payload of the defined request payload
   type and returns an instance of `AuthResponse` which contains two fields:
   * `success` (bool) - Whether or not the authentication attempt was successful
+  * `orchestrator_name` (str) - A string identifying the orchestrator the
+  authentication is being performed for
   * `user_id` (str) - A string identifying the authenticated user
 
 This class should always return a response of the specified type and not raise

--- a/src/orchestrators/assistant-orchestrator/services/auth/authenticator.py
+++ b/src/orchestrators/assistant-orchestrator/services/auth/authenticator.py
@@ -7,10 +7,11 @@ T = TypeVar("T")
 
 class AuthResponse(BaseModel):
     success: bool
+    orch_name: str
     user_id: str
 
 
 class Authenticator(ABC, Generic[T]):
     @abstractmethod
-    def authenticate(self, request: T) -> AuthResponse:
+    def authenticate(self, orchestrator_name: str, request: T) -> AuthResponse:
         pass

--- a/src/orchestrators/assistant-orchestrator/services/auth/custom/example_custom_authenticator.py
+++ b/src/orchestrators/assistant-orchestrator/services/auth/custom/example_custom_authenticator.py
@@ -7,8 +7,8 @@ class ExampleUserIdOnlyAuthRequest(BaseModel):
 
 
 class ExampleUserIdOnlyAuthenticator(Authenticator[ExampleUserIdOnlyAuthRequest]):
-    def authenticate(self, request: ExampleUserIdOnlyAuthRequest) -> AuthResponse:
+    def authenticate(self, orchestrator_name: str, request: ExampleUserIdOnlyAuthRequest) -> AuthResponse:
         if request.user_id == "good_id":
-            return AuthResponse(success=True, user_id=request.user_id)
+            return AuthResponse(success=True, orch_name=orchestrator_name, user_id=request.user_id)
         else:
-            return AuthResponse(success=False, user_id=request.user_id)
+            return AuthResponse(success=False, orch_name=orchestrator_name, user_id=request.user_id)

--- a/src/orchestrators/assistant-orchestrator/services/auth/user_id_only_authenticator.py
+++ b/src/orchestrators/assistant-orchestrator/services/auth/user_id_only_authenticator.py
@@ -7,5 +7,5 @@ class UserIdOnlyAuthRequest(BaseModel):
 
 
 class UserIdOnlyAuthenticator(Authenticator[UserIdOnlyAuthRequest]):
-    def authenticate(self, request: UserIdOnlyAuthRequest) -> AuthResponse:
-        return AuthResponse(success=True, user_id=request.user_id)
+    def authenticate(self, orchestrator_name: str, request: UserIdOnlyAuthRequest) -> AuthResponse:
+        return AuthResponse(success=True, orch_name=orchestrator_name, user_id=request.user_id)

--- a/src/orchestrators/assistant-orchestrator/services/model/responses.py
+++ b/src/orchestrators/assistant-orchestrator/services/model/responses.py
@@ -24,6 +24,7 @@ class GeneralResponse(BaseModel):
 
 
 class AuthenticationResponse(BaseModel):
+    orchestrator_name: str
     user_id: str
 
 

--- a/src/orchestrators/assistant-orchestrator/services/ska_services.py
+++ b/src/orchestrators/assistant-orchestrator/services/ska_services.py
@@ -53,13 +53,13 @@ authenticator: Authenticator[auth_helper.get_request_type()] = (
 )
 
 
-@app.post("/services/v1/authenticate")
+@app.post("/services/v1/{orchestrator_name}/authenticate")
 async def authenticate_user(
-    payload: auth_helper.get_request_type(),
+    orchestrator_name: str, payload: auth_helper.get_request_type()
 ) -> AuthenticationResponse:
-    auth_response = authenticator.authenticate(payload)
+    auth_response = authenticator.authenticate(orchestrator_name, payload)
     if auth_response.success:
-        return AuthenticationResponse(user_id=auth_response.user_id)
+        return AuthenticationResponse(orchestrator_name=auth_response.orch_name, user_id=auth_response.user_id)
     else:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Authentication Failed"

--- a/src/orchestrators/assistant-orchestrator/services/ska_services.py
+++ b/src/orchestrators/assistant-orchestrator/services/ska_services.py
@@ -75,7 +75,7 @@ async def create_ticket(
         ip_address = request.headers.get("X-Forwarded-For")
     else:
         ip_address = request.client.host
-    auth_response = authenticator.authenticate(payload)
+    auth_response = authenticator.authenticate(orchestrator_name, payload)
     if auth_response.success:
         return CreateTicketResponse(
             ticket=ticket_manager.create_ticket(


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Currently, the authenticate service in ao-services does not account for which orchestrator the authentication is being performed for.  This is wrong and the orchestrator name needs to be included in this service and distributed to downstream capability. This PR addresses those issues.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- Added orchestrator_name as a parameter in method `authenticate` in abstract class Authenticator and updated "authenticate" and "create ticket" services accordingly.
- Updated "user_id_only_authenticator" and "example_custom_authenticator" to include Orchestrator name
- Updated Authentication Response to include Orchestrator name
- Updated relevant README

## Type of Change
<!-- Please check the type of change that applies: -->
- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/1513421c-b05e-4a50-8afd-82054ea2774f" />


## Additional Comments
<!-- Include any other relevant information or comments here. -->
