### PR TITLE
Streamline REST Endpoints to just GET and POST

### DIFF
--- a/src/orchestrators/assistant-orchestrator/orchestrator/routes/apis.py
+++ b/src/orchestrators/assistant-orchestrator/orchestrator/routes/apis.py
@@ -57,6 +57,7 @@ async def add_conversation_message_by_id(
 ):
     jt = get_telemetry()
 
+    # start a new conversation if no session id was provided
     if session_id is None:
         with (
             jt.tracer.start_as_current_span("init-conversation")
@@ -70,8 +71,9 @@ async def add_conversation_message_by_id(
                 raise HTTPException(
                     status_code=500, detail=f"Error creating new conversation --- {e}"
                 )
+    
+    # get conversation history if session id was provided
     else:
-
         try:
             conv = conv_manager.get_conversation(user_id, session_id)
         except Exception as e:
@@ -79,13 +81,7 @@ async def add_conversation_message_by_id(
                 status_code=404,
                 detail=f"Unable to get conversation with session_id: {session_id} --- {e}",
             )
-    
-    print(user_id)
-    print(session_id)
-    print(request)
-    print(authorization)
-    print(conv)
-    
+        
     in_memory_user_context = None
     if cache_user_context:
         in_memory_user_context = cache_user_context.get_user_context_from_cache(


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Send a message to a conversation based on a session id. If session id is not provided, a new conversation will be created.
Want to streamline our APIs for TalkGPTeal team and others.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
Update api.py to remove "new conversation" and combine both functionalities under POST conversations

## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (please specify): Small change to APIs

## Screenshots (if applicable)
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/a424f75d-e150-4fed-ac6c-d3a1cf63a63e" />
<img width="917" alt="image" src="https://github.com/user-attachments/assets/ec274938-f7f2-4f54-88dc-7dd3b22c60d8" />

