### PR TITLE
New endpoint to initiate A2A

### DIFF
--- a/src/sk-agents/src/sk_agents/a2a_types.py
+++ b/src/sk-agents/src/sk_agents/a2a_types.py
@@ -1,18 +1,23 @@
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
 from sk_agents.ska_types import BaseMultiModalInput, InvokeResponse, PartialResponse
 
 
-class A2AEventType(Enum):
+class A2AEventType(str, Enum):
     INVOKE = "INVOKE"
     INVOKE_STREAM = "INVOKE_STREAM"
     PARTIAL_RESPONSE = "PARTIAL_RESPONSE"
     FINAL_RESPONSE = "FINAL_RESPONSE"
     EXTRA_DATA = "EXTRA_DATA"
     ERROR = "ERROR"
+
+
+class A2AInvokeResponse(BaseModel):
+    event_id: str
+    topic: str
 
 
 class A2ABaseEvent(BaseModel):
@@ -22,7 +27,9 @@ class A2ABaseEvent(BaseModel):
 
 class A2AInvokeEvent(A2ABaseEvent):
     event_id: str
-    event_type: A2AEventType = A2AEventType.INVOKE
+    event_type: Literal[A2AEventType.INVOKE, A2AEventType.INVOKE_STREAM] = (
+        A2AEventType.INVOKE
+    )
     event_data: BaseMultiModalInput
 
 

--- a/src/sk-agents/src/sk_agents/appv2.py
+++ b/src/sk-agents/src/sk_agents/appv2.py
@@ -19,7 +19,9 @@ from sk_agents.utils import initialize_plugin_loader
 
 class AppV2:
     @staticmethod
-    def run(name: str, version: str, app_config: AppConfig, config: BaseConfig, app: FastAPI):
+    def run(
+        name: str, version: str, app_config: AppConfig, config: BaseConfig, app: FastAPI
+    ):
         config_file = app_config.get(TA_SERVICE_CONFIG.env_name)
         agents_path = str(os.path.dirname(config_file))
 
@@ -61,6 +63,12 @@ class AppV2:
                 config=config,
                 app_config=app_config,
                 input_class=BaseMultiModalInput,
+            ),
+            prefix=f"/{name}/{version}",
+        )
+        app.include_router(
+            Routes.get_a2a_rest_routes(
+                name=name, version=version, app_config=app_config
             ),
             prefix=f"/{name}/{version}",
         )

--- a/src/sk-agents/src/sk_agents/routes.py
+++ b/src/sk-agents/src/sk_agents/routes.py
@@ -1,10 +1,13 @@
 from contextlib import nullcontext
 
-from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
+from dapr.clients import DaprClient
+from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.responses import StreamingResponse
 from opentelemetry.propagate import extract
 from ska_utils import AppConfig, get_telemetry
 
+from sk_agents.a2a_types import A2AInvokeEvent, A2AInvokeResponse, A2AEventType
+from sk_agents.configs import TA_A2A_EVENT_SOURCE_NAME
 from sk_agents.ska_types import (
     BaseConfig,
     BaseHandler,
@@ -49,7 +52,9 @@ class Routes:
             ):
                 match root_handler_name:
                     case "skagents":
-                        handler: BaseHandler = skagents_handle(config, app_config, authorization)
+                        handler: BaseHandler = skagents_handle(
+                            config, app_config, authorization
+                        )
                     case _:
                         raise ValueError(f"Unknown apiVersion: {config.apiVersion}")
 
@@ -59,7 +64,9 @@ class Routes:
 
         @router.post("/sse")
         @docstring_parameter(description)
-        async def invoke_sse(inputs: input_class, request: Request) -> StreamingResponse:
+        async def invoke_sse(
+            inputs: input_class, request: Request
+        ) -> StreamingResponse:
             """
             Stream data to the client using Server-Sent Events (SSE).
             """
@@ -83,12 +90,58 @@ class Routes:
                                 config, app_config, authorization
                             )
                             # noinspection PyTypeChecker
-                            async for content in handler.invoke_stream(inputs=inv_inputs):
+                            async for content in handler.invoke_stream(
+                                inputs=inv_inputs
+                            ):
                                 yield get_sse_event_for_response(content)
                         case _:
                             raise ValueError(f"Unknown apiVersion: {config.apiVersion}")
 
             return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+        return router
+
+    @staticmethod
+    def get_a2a_rest_routes(
+        name: str, version: str, app_config: AppConfig
+    ) -> APIRouter:
+        router = APIRouter()
+
+        def _assert_valid_event(a2a_event: A2AInvokeEvent) -> None:
+            if not a2a_event.event_id:
+                raise HTTPException(
+                    status_code=400, detail="Invalid event data - Missing event_id"
+                )
+            if not a2a_event.event_type or (
+                a2a_event.event_type != A2AEventType.INVOKE
+                and a2a_event.event_type != A2AEventType.INVOKE_STREAM
+            ):
+                raise HTTPException(
+                    status_code=400, detail="Invalid event data - Invalid event_type"
+                )
+
+        @router.post("/a2a")
+        async def invoke_a2a(a2a_event: A2AInvokeEvent) -> A2AInvokeResponse:
+            _assert_valid_event(a2a_event)
+
+            event_source_name = app_config.get(TA_A2A_EVENT_SOURCE_NAME.env_name)
+            with DaprClient() as client:
+                try:
+                    client.publish_event(
+                        pubsub_name=event_source_name,
+                        topic_name=f"{name}/{version}",
+                        data=a2a_event.model_dump_json(),
+                        data_content_type="application/json",
+                    )
+                    return A2AInvokeResponse(
+                        event_id=a2a_event.event_id,
+                        topic=f"{name}/{version}/{a2a_event.event_id}",
+                    )
+                except Exception as e:
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Failed to publish event: {str(e)}",
+                    )
 
         return router
 
@@ -128,7 +181,9 @@ class Routes:
                                 config, app_config, authorization
                             )
                             # noinspection PyTypeChecker
-                            async for content in handler.invoke_stream(inputs=inv_inputs):
+                            async for content in handler.invoke_stream(
+                                inputs=inv_inputs
+                            ):
                                 if isinstance(content, PartialResponse):
                                     await websocket.send_text(content.output_partial)
                             await websocket.close()

--- a/src/sk-agents/src/sk_agents/ska_types.py
+++ b/src/sk-agents/src/sk_agents/ska_types.py
@@ -63,7 +63,7 @@ class BaseEmbeddedImage(KernelBaseModel):
 
 
 class MultiModalItem(BaseModel):
-    content_type: ContentType
+    content_type: ContentType = ContentType.TEXT
     content: str
 
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Creation of a new endpoint in A2A mode which validates a payload and then submits the request to the appropriate topic for a given agent.  We'll require anybody invoking the agent via pub/sub to initiate the interaction via this endpoint to allow us to validate payloads prior to actually sending the request.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- New endpoint for A2A task submission via topic

## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->

## Additional Comments
<!-- Include any other relevant information or comments here. -->
