### PR TITLE
Update to use name instead of service_name

### DIFF
--- a/src/sk-agents/src/sk_agents/app.py
+++ b/src/sk-agents/src/sk_agents/app.py
@@ -53,11 +53,11 @@ try:
     if root_handler == "tealagents":
         if api_version == "v1alpha1":
             app_version = AppVersion.V3
-            name = config.service_name
+            name = config.name
     elif root_handler == "skagents":
         if api_version == "v2alpha1":
             app_version = AppVersion.V2
-            name = config.service_name
+            name = config.name
         else:
             app_version = AppVersion.V1
             name = config.service_name

--- a/src/sk-agents/tests/test_app.py
+++ b/src/sk-agents/tests/test_app.py
@@ -122,7 +122,7 @@ def test_app_v2_initialization_successful(
 
     # Provide v2 config object
     mock_config_v2 = MockBaseConfig(
-        apiVersion="skagents/v2alpha1", version="2.0.0", service_name="test-service-v2"
+        apiVersion="skagents/v2alpha1", version="2.0.0", name="test-service-v2"
     )
     mock_parse_yaml.return_value = mock_config_v2
 
@@ -164,7 +164,7 @@ def test_app_v3_initialization_successful(
 
     # Provide v3 config object
     mock_config_v3 = MockBaseConfig(
-        apiVersion="tealagents/v1alpha1", version="2.0.0", service_name="test-service-v3"
+        apiVersion="tealagents/v1alpha1", version="2.0.0", name="test-service-v3"
     )
     mock_parse_yaml.return_value = mock_config_v3
 
@@ -257,7 +257,7 @@ def test_missing_service_version_in_config(mock_app_config, mock_parse_yaml):
     mock_config_missing_version = MockBaseConfig(
         apiVersion="skagents/v2alpha1",  # or v1alpha1
         version="",
-        service_name="test-service",
+        name="test-service",
     )
     mock_parse_yaml.return_value = mock_config_missing_version
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Update to use name instead of service_name from the config files for apiVersions other than v1.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- Update `app.py` to use `name` instead of `service_name` for non-v1 versions
- Update unit tests

## Type of Change
<!-- Please check the type of change that applies: -->
- [x] Bugfix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->

## Additional Comments
<!-- Include any other relevant information or comments here. -->
