### PR TITLE
add temperature in prompt execution settings

### DIFF
--- a/src/sk-agents/src/sk_agents/skagents/v1/agent_builder.py
+++ b/src/sk-agents/src/sk_agents/skagents/v1/agent_builder.py
@@ -40,6 +40,9 @@ class AgentBuilder:
 
         settings = kernel.get_prompt_execution_settings_from_service_id(agent_config.name)
         settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
+        if agent_config.temperature:
+            settings.extension_data = {"temperature": float(agent_config.temperature)}
+            settings.unpack_extension_data()
         if so_supported and output_type:
             type_loader = get_type_loader()
             settings.response_format = type_loader.get_type(output_type)

--- a/src/sk-agents/src/sk_agents/skagents/v1/config.py
+++ b/src/sk-agents/src/sk_agents/skagents/v1/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AgentConfig(BaseModel):
@@ -6,6 +6,7 @@ class AgentConfig(BaseModel):
 
     name: str
     model: str
+    temperature: float | None = Field(None, ge=0.0, le=1.0)
     system_prompt: str
     plugins: list[str] | None = None
     remote_plugins: list[str] | None = None


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Support model temperature 

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- AgentBuilder add model temperature in the prompt execution settings
- AgentConfigs enable new field temperature in agent config spec. Default temperature is None, and restricted values between 0.0 to 1.0


## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->

<img width="737" height="663" alt="image" src="https://github.com/user-attachments/assets/8d1ba1ca-dd40-46c4-83d0-25394e8e06eb" />

<img width="724" height="554" alt="image" src="https://github.com/user-attachments/assets/3b86852a-e36c-459b-b86a-af752d5e2a57" />


## Additional Comments
<!-- Include any other relevant information or comments here. -->
