### PR TITLE
Extend handler for manual tool invocation loop

### DIFF
--- a/src/sk-agents/src/sk_agents/tealagents/v1alpha1/hitl_manager.py
+++ b/src/sk-agents/src/sk_agents/tealagents/v1alpha1/hitl_manager.py
@@ -1,0 +1,17 @@
+from semantic_kernel.contents.function_call_content import FunctionCallContent
+
+
+def check_for_intervention(tool_call: FunctionCallContent) -> bool:
+    """
+    Placeholder for HITL logic. In the future, this will check
+    if the tool call requires user consent based on configured policies.
+
+    Returns False for now, allowing all calls to proceed without interruption.
+    """
+
+    # TODO: Implement actual policy checks for high-risk tools
+    print(
+        f"HITL Check: Intercepted call to {tool_call.plugin_name}."
+        f"{tool_call.function_name}. Allowing to proceed."
+    )
+    return False


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the motivation for the change. -->
Refactor agent invocation process to allow for manual interception of tool calls as outlined in `src/sk-agents/planning/2507-state-hitl-auth/02-02-manual-tool-call-implementation-plan.md`. This is the phase 2 portion of the HITL+Auth implementation.

## Changes
<!-- List the changes made in this PR. Include any relevant information or context. -->
- Created new HITL place holder module `hitl_manager.py`
- Refactored agent handler to align with the implementation plan outlined in `src/sk-agents/planning/2507-state-hitl-auth/02-02-manual-tool-call-implementation-plan.md`
- Updated unit test for `test_v1alpha1_agent_handler.py`

## Type of Change
<!-- Please check the type of change that applies: -->
- [ ] Bugfix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): ____________

## Screenshots (if applicable)
<!-- Include screenshots to help explain the changes, if necessary. -->

## Additional Comments
<!-- Include any other relevant information or comments here. -->
Currently there isn't a way to fully test this change until the other parts of the HITL+AUTH implementation are in place and everything is connected together.

Based off future integration testing, there may (or may not) require additional changes to be made. These changes were made following the plan outlined in `src/sk-agents/planning/2507-state-hitl-auth/02-02-manual-tool-call-implementation-plan.md` while still preserving the additional functionality of the authorization and user context pieces that were added previously.
